### PR TITLE
Add missing comma

### DIFF
--- a/include/RecoEvent.hpp
+++ b/include/RecoEvent.hpp
@@ -1094,7 +1094,7 @@ void RecoEvent::Init(bool isMC, std::string triggerFlag, TTree *tree)
      fChain->SetBranchAddress("genJetPF2PATPX", genJetPF2PATPX, &b_genJetPF2PATPX);
      fChain->SetBranchAddress("genJetPF2PATPY", genJetPF2PATPY, &b_genJetPF2PATPY);
      fChain->SetBranchAddress("genJetPF2PATPZ", genJetPF2PATPZ, &b_genJetPF2PATPZ);
-     fChain->SetBranchAddress("genJetPF2PATID", genJetPF2PATPID &b_genJetPF2PATID);
+     fChain->SetBranchAddress("genJetPF2PATID", genJetPF2PATPID, &b_genJetPF2PATID);
      fChain->SetBranchAddress("genJetPF2PATPhi", genJetPF2PATPhi, &b_genJetPF2PATPhi);
      fChain->SetBranchAddress("genJetPF2PATTheta", genJetPF2PATTheta, &b_genJetPF2PATTheta);
      fChain->SetBranchAddress("genJetPF2PATEta", genJetPF2PATEta, &b_genJetPF2PATEta);


### PR DESCRIPTION
Commpilation currently fails due to a missing comma in this function call introduced in b8e156670ea11447527a243f0aebdb1c0dd622fd
