### PR TITLE
Fix compilation under ROOT6

### DIFF
--- a/include/analysisAlgo.hpp
+++ b/include/analysisAlgo.hpp
@@ -23,7 +23,7 @@ class AnalysisAlgo{
         AnalysisAlgo();
         ~AnalysisAlgo();
 
-	double zptSF(TString channel, float zpt);
+	double zptSF(std::string channel, float zpt);
 	void setBranchStatusAll(TTree * chain, bool isMC, std::string triggerFlag);
 	void show_usage(std::string name);
 

--- a/src/common/analysisAlgo.cpp
+++ b/src/common/analysisAlgo.cpp
@@ -46,7 +46,7 @@ AnalysisAlgo::AnalysisAlgo():
 
 AnalysisAlgo::~AnalysisAlgo(){}
 
-double AnalysisAlgo::zptSF(TString channel, float zpt){
+double AnalysisAlgo::zptSF(std::string channel, float zpt){
 
   double param1 = 0;
   double param2 = 0;


### PR DESCRIPTION
The function zptSF takes a TString as a paramater but is only ever
passed a std::string. This implicit conversion causes linker errors in
recent versions of ROOT.

Solution: take a std::string as a paramater instead of a TString.
