### PR TITLE
Use LHAPDF6

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,8 +9,9 @@ EXECUTABLE_OBJECT_FILES = $(patsubst src/common/%.cxx,obj/%.o,${EXECUTABLE_SOURC
 EXECUTABLES = $(patsubst src/common/%.cxx,bin/%.exe,${EXECUTABLE_SOURCES})
 
 LIBRARY_PATH = 	-L$(shell root-config --libdir) \
-		-Llib \
 		-L/scratch/shared/lib \
+		-L/usr/lib64/include/boost \
+		-Llib \
 
 LIBRARIES = 	$(shell root-config --libs) \
 		-lLHAPDF \
@@ -19,8 +20,9 @@ LIBRARIES = 	$(shell root-config --libs) \
 		-lz \
 
 INCLUDE_PATH = 	-Iinclude  \
-		-I/usr/include \
 		-isystem/scratch/shared/include \
+		-isystem/usr/include/boost148 \
+		-I/usr/include \
 		-isystem$(shell root-config --incdir) \
 
 CFLAGS = -std=c++14 -march=native -mtune=native -g -O2 -pipe -Wall -Wextra \

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,6 @@
+# Point LHAPDF to pdf sets
+export LHAPATH=/cvmfs/cms.cern.ch/lhapdf/pdfsets/6.1.6/
+
 export TQZ_TOOLS_PATH='.'
 source /opt/rh/devtoolset-3/enable
 source /opt/rh/git19/enable


### PR DESCRIPTION
Include the boost version LHAPDF6 was built with (requires a more recent version than the standard distributed with sl6) and point it to the PDF sets stored on LHAPDF.

Since .LHgrid files are no more I imagine the `LHAPDF::initPDFSet(1, "CT14nnlo.LHgrid")` call is deprecated, but seems to still work!

This fixes the issues using CT14nnlo.
