### PR TITLE
Throw an exception if the mvaOutFile cannot be opened

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ EXECUTABLES = $(patsubst src/common/%.cxx,bin/%.exe,${EXECUTABLE_SOURCES})
 
 LIBRARY_PATH = 	-L$(shell root-config --libdir) \
 		-L/scratch/shared/lib \
-		-L/usr/lib64/include/boost \
+		-L/usr/lib64/boost148 \
 		-Llib \
 
 LIBRARIES = 	$(shell root-config --libs) \
@@ -18,6 +18,8 @@ LIBRARIES = 	$(shell root-config --libs) \
 		-lTMVA  \
 		-lconfig++ \
 		-lz \
+		-lboost_system-mt \
+		-lboost_filesystem-mt \
 
 INCLUDE_PATH = 	-Iinclude  \
 		-isystem/scratch/shared/include \

--- a/src/common/analysisAlgo.cpp
+++ b/src/common/analysisAlgo.cpp
@@ -6,6 +6,7 @@
 #include "AnalysisEvent.hpp"
 
 #include <boost/numeric/conversion/cast.hpp>
+#include <boost/filesystem.hpp>
 #include <iomanip>
 #include <cmath>
 #include <iostream>
@@ -858,9 +859,10 @@ void AnalysisAlgo::runMainAnalysis(){
       //Now add in the branches:
     
       if (makeMVATree){
+        boost::filesystem::create_directory(mvaDir);
         mvaOutFile = new TFile{(mvaDir + dataset->name() + postfix + (invertIsoCut?"invIso":"")  +  "mvaOut.root").c_str(),"RECREATE"};
         if (!mvaOutFile->IsOpen()) {
-          throw std::runtime_error("TFile could not be opened! Make sure the directory exists!");
+          throw std::runtime_error("MVA Tree TFile could not be opened!");
         }
         int systMask{1};
 	std::cout << "Making systematic trees for " << dataset->name() << ": ";

--- a/src/common/analysisAlgo.cpp
+++ b/src/common/analysisAlgo.cpp
@@ -859,6 +859,9 @@ void AnalysisAlgo::runMainAnalysis(){
     
       if (makeMVATree){
         mvaOutFile = new TFile{(mvaDir + dataset->name() + postfix + (invertIsoCut?"invIso":"")  +  "mvaOut.root").c_str(),"RECREATE"};
+        if (!mvaOutFile->IsOpen()) {
+          throw std::runtime_error("TFile could not be opened! Make sure the directory exists!");
+        }
         int systMask{1};
 	std::cout << "Making systematic trees for " << dataset->name() << ": ";
 	for (unsigned systIn{0}; systIn < systNames.size(); systIn++){


### PR DESCRIPTION
Turns out the problems I was having today were because I hadn't created the mvaTest directory.This caused the trees to become memory resident rather than the program to fail, which I think is the better option.

This check could be applied to the other TFiles, too.
